### PR TITLE
Fix get running processes

### DIFF
--- a/app/src/main/java/com/hmatalonga/greenhub/Config.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/Config.java
@@ -63,6 +63,7 @@ public final class Config {
     public static final String IMPORTANCE_DISABLED = "disabled";
     public static final String IMPORTANCE_INSTALLED = "installed";
     public static final String IMPORTANCE_REPLACED = "replaced";
+    public static final int IMPORTANCE_APP = 9999;
 
     public static final String BATTERY_SOURCE_DEFAULT =
             "/sys/class/power_supply/battery/current_now";

--- a/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/Inspector.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/Inspector.java
@@ -56,6 +56,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PermissionInfo;
 import android.os.BatteryManager;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
@@ -93,6 +94,7 @@ import com.hmatalonga.greenhub.models.data.Sample;
 import com.hmatalonga.greenhub.models.data.Settings;
 import com.hmatalonga.greenhub.util.Notifier;
 import com.hmatalonga.greenhub.util.SettingsUtils;
+import com.hmatalonga.greenhub.util.StringHelper;
 
 import org.greenrobot.eventbus.EventBus;
 
@@ -204,7 +206,12 @@ public final class Inspector {
         // Reset list for each sample
         Process.clear();
 
-        List<ProcessInfo> list = Application.getRunningAppInfo(context);
+        List<ProcessInfo> list;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            list = Application.getRunningAppInfo(context);
+        } else {
+            list = Application.getRunningAppInfoLegacy(context);
+        }
         List<ProcessInfo> result = new ArrayList<>();
 
         PackageManager pm = context.getPackageManager();
@@ -219,7 +226,7 @@ public final class Inspector {
                 (included) ? Package.getInstalledPackages(context, false) : null;
 
         for (ProcessInfo pi : list) {
-            String pName = pi.name;
+            String pName = StringHelper.formatProcessName(pi.name);
             if (processInfoMap != null && processInfoMap.containsKey(pName)) {
                 processInfoMap.remove(pName);
             }
@@ -231,6 +238,7 @@ public final class Inspector {
             item.appSignatures = new RealmList<>();
 
             PackageInfo packageInfo = Package.getPackageInfo(context, pName);
+            LOGI("getRunningProcessInfoForSample","ProcessName: "+pName);
 
             if (packageInfo != null) {
                 item.versionName = packageInfo.versionName;

--- a/app/src/main/java/com/hmatalonga/greenhub/models/Application.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/models/Application.java
@@ -27,14 +27,62 @@ import java.util.List;
 import java.util.Set;
 
 import com.hmatalonga.greenhub.models.data.ProcessInfo;
+import com.hmatalonga.greenhub.util.ProcessUtils;
 import com.hmatalonga.greenhub.util.StringHelper;
 
+import static com.hmatalonga.greenhub.util.LogUtils.LOGE;
+import static com.hmatalonga.greenhub.util.LogUtils.LOGI;
 import static com.hmatalonga.greenhub.util.LogUtils.makeLogTag;
 
 /**
  * Application properties model.
  */
 public class Application {
+
+    public static ArrayList<ProcessInfo> getRunningAppInfoLegacy(final Context context) {
+        ArrayList<ProcessInfo> processInfoList = new ArrayList<>();
+        List<String> psOutput = ProcessUtils.getCommandOutputAsList("ps");
+        psOutput.remove(0); // the first line contains the headers of the `ps` command,
+                              // so we just discard that
+
+        for (String line : psOutput) {
+            String[] properties = line.split("[ \\t]+");
+            if (properties.length >= 9) {
+                String cmdUser = properties[0];
+                String cmdPid = properties[1];
+                String cmdName = properties[8];
+                String description = "";
+
+                if (cmdUser.matches("u[0-9]+_.+")) {
+                    if (cmdName.matches("(\\w+(\\.\\w+)+)$")) {  // this is a normal app
+                        description = "user";
+                    }else if (cmdName.matches("(\\w+(\\.\\w+)+:\\w+)$")) {  // this is a service
+                        description = "user-service";
+                    }else{
+                        description = "unknown";
+                    }
+                }else{
+                    description = "system";
+                }
+
+                ProcessInfo item = new ProcessInfo();
+                item.importance = StringHelper.importanceStringLegacy(description);
+                try {
+                    int pid = Integer.parseInt(cmdPid);
+                    item.processId = pid;
+                }catch (NumberFormatException e) {
+                    LOGE("Wrong PID format: ", "" + cmdPid);
+                    item.processId = -1;  // FIXME: what should the PID be in an error situation?
+                }
+                item.name = cmdName;  // FIXME:
+                processInfoList.add(item);
+
+            }
+        }
+
+        return null;
+    }
+
     public static ArrayList<ProcessInfo> getRunningAppInfo(final Context context) {
         List<RunningAppProcessInfo> runningProcessInfo = Process.getRunningProcessInfo(context);
         List<RunningServiceInfo> runningServices = Service.getRunningServiceInfo(context);

--- a/app/src/main/java/com/hmatalonga/greenhub/models/Battery.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/models/Battery.java
@@ -328,7 +328,6 @@ public class Battery {
 		if (!charging) {
 			chargingSignal = -1;
 			remainingCapacity = getBatteryRemainingCapacity(context);
-			LOGI("WOW", "[B] RemCap: " + remainingCapacity);
 		} else {
 			chargingSignal = 1;
 			switch (charger) {
@@ -435,28 +434,4 @@ public class Battery {
 		return value;
 	}
 
-	public static void logAllBatteryValues(final Context context) {
-		BatteryManager manager = (BatteryManager) context.getSystemService(Context.BATTERY_SERVICE);
-
-		LOGI("Battery Voltage", "v: " + getBatteryVoltage(context));
-		if (Build.VERSION.SDK_INT >= 21) {
-			LOGI("[API] Battery Capacity", "v: " + manager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY));
-			LOGI("[API] Battery Charge Counter", "v: " + manager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CHARGE_COUNTER));
-			LOGI("[API] Battery Energy Counter", "v: " + manager.getIntProperty(BatteryManager.BATTERY_PROPERTY_ENERGY_COUNTER));
-			LOGI("[API] Battery Current Average", "v: " + manager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_AVERAGE));
-			LOGI("[API] Battery Current Now", "v: " + manager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW));
-		}
-
-		LOGI("Battery Capacity", "v: " + getBatteryPropertyLegacy(Config.BATTERY_CAPACITY));
-		LOGI("Battery Charge Counter", "v: " + getBatteryPropertyLegacy(Config.BATTERY_CHARGE_FULL));
-		LOGI("Battery Charge Counter (Design)", "v: " + getBatteryPropertyLegacy(Config.BATTERY_CHARGE_FULL_DESIGN));
-		LOGI("Battery Energy Counter", "v: " + getBatteryPropertyLegacy(Config.BATTERY_ENERGY_FULL));
-		LOGI("Battery Energy Counter (Design)", "v: " + getBatteryPropertyLegacy(Config.BATTERY_ENERGY_FULL_DESIGN));
-		LOGI("Battery Current Now", "v: " + getBatteryPropertyLegacy(Config.BATTERY_CURRENT_NOW));
-		LOGI("Battery Current Now (2)", "v: " + getBatteryCurrentNowLegacy());
-		LOGI("Battery Energy Now", "v: " + getBatteryPropertyLegacy(Config.BATTERY_ENERGY_NOW));
-
-		//Reflections
-		LOGI("Actual Battery Capacity", "v: " + getActualBatteryCapacity(context));
-	}
 }

--- a/app/src/main/java/com/hmatalonga/greenhub/util/ProcessUtils.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/util/ProcessUtils.java
@@ -1,0 +1,52 @@
+package com.hmatalonga.greenhub.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Created by marco on 12-03-2018.
+ */
+
+public class ProcessUtils {
+
+    public static List<String> getCommandOutputAsList(String command) {
+        String[] lines = getCommandOutput(command).split(System.getProperty("line.separator"));
+        return Arrays.asList(lines);
+    }
+
+    public static String getCommandOutput(String command) {
+
+        try {
+            // Executes the command.
+            Process process = Runtime.getRuntime().exec(command);
+
+            // Reads stdout.
+            // NOTE: You can write to stdin of the command using
+            //       process.getOutputStream().
+            BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()));
+
+            int read;
+            char[] buffer = new char[4096];
+            StringBuffer output = new StringBuffer();
+            while ((read = reader.read(buffer)) > 0) {
+                output.append(buffer, 0, read);
+            }
+            reader.close();
+
+            // Waits for the command to finish.
+            process.waitFor();
+
+            return output.toString();
+
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/app/src/main/java/com/hmatalonga/greenhub/util/StringHelper.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/util/StringHelper.java
@@ -23,6 +23,7 @@ import android.util.SparseArray;
 import java.text.NumberFormat;
 import java.util.List;
 
+import com.hmatalonga.greenhub.Config;
 import com.hmatalonga.greenhub.R;
 
 import static com.hmatalonga.greenhub.util.LogUtils.LOGE;
@@ -37,11 +38,15 @@ public class StringHelper {
 
     static {
         importanceToString = new SparseArray<>();
+        // for API >=  26, both IMPORTANCE_EMPTY and IMPORTANCE_BACKGROUND
+        // will mean the same thing, and the constant name is IMPORTANCE_CACHED
+        importanceToString.put(RunningAppProcessInfo.IMPORTANCE_CACHED, "Not running");
         importanceToString.put(RunningAppProcessInfo.IMPORTANCE_EMPTY, "Not running");
         importanceToString.put(RunningAppProcessInfo.IMPORTANCE_BACKGROUND, "Background process");
         importanceToString.put(RunningAppProcessInfo.IMPORTANCE_SERVICE, "Service");
         importanceToString.put(RunningAppProcessInfo.IMPORTANCE_VISIBLE, "Visible task");
         importanceToString.put(RunningAppProcessInfo.IMPORTANCE_FOREGROUND, "Foreground app");
+        importanceToString.put(Config.IMPORTANCE_APP , "App");
     }
 
     /**
@@ -57,6 +62,26 @@ public class StringHelper {
             s = "Unknown";
         }
         return s;
+    }
+
+    public static String importanceStringLegacy(String description) {
+        String importance;
+        switch (description) {
+            case "system" :
+                importance = importanceString(RunningAppProcessInfo.IMPORTANCE_BACKGROUND);
+                break;
+            case "user" :
+                importance = importanceString(Config.IMPORTANCE_APP);
+                break;
+            case "user-service" :
+                importance = importanceString(RunningAppProcessInfo.IMPORTANCE_SERVICE);
+                break;
+            default :
+                importance = "Unknown";
+                break;
+        }
+
+        return importance;
     }
 
     public static String translatedPriority(final Context context, String importanceString) {


### PR DESCRIPTION
This PR fixes issue #66 .
It checks if the API version is equal or higher then 24 (Nougat), and if so it uses a legacy method instead of the normal one to get the list of runing applications.

Please test this properly with phone using Android 7.0 or higher. since I could only test this with a phone using a custom 7.0 ROM.