### PR TITLE
Remove Explicit Wakelock Usage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -128,6 +128,15 @@
             android:name=".managers.sampling.DataEstimatorService"
             android:label="BatteryEstimatorService" />
 
+        <service
+            android:name=".managers.sampling.BatteryService"
+            android:label="BatteryBroadcastReceiver" />
+
+        <service
+            android:name=".managers.sampling.DataEstimator$EstimatorJob"
+            android:label="EstimatorJob"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+
         <receiver android:name=".receivers.ConnectivityReceiver">
             <intent-filter>
                 <action android:name="android.net.conn.CONNECTIVITY_CHANGE"/>

--- a/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/BatteryService.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/BatteryService.java
@@ -1,0 +1,67 @@
+package com.hmatalonga.greenhub.managers.sampling;
+
+
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.IBinder;
+
+import com.hmatalonga.greenhub.util.SettingsUtils;
+
+import static com.hmatalonga.greenhub.util.LogUtils.logE;
+import static com.hmatalonga.greenhub.util.LogUtils.makeLogTag;
+
+/**
+ * Created by marco on 06-03-2019.
+ */
+
+public class BatteryService extends Service {
+
+    private static final String TAG = makeLogTag(BatteryService.class);
+    public static boolean isServiceRunning = false;
+
+    private IntentFilter mIntentFilter;
+
+    public static DataEstimator estimator = null;
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        isServiceRunning = true;
+
+        estimator = new DataEstimator();
+
+        mIntentFilter = new IntentFilter();
+        mIntentFilter.addAction(Intent.ACTION_BATTERY_CHANGED);
+
+        Context context = getApplicationContext();
+
+        registerReceiver(estimator, mIntentFilter);
+
+        if (SettingsUtils.isSamplingScreenOn(context)) {
+            mIntentFilter.addAction(Intent.ACTION_SCREEN_ON);
+            registerReceiver(estimator, mIntentFilter);
+            mIntentFilter.addAction(Intent.ACTION_SCREEN_OFF);
+            registerReceiver(estimator, mIntentFilter);
+        }
+
+    }
+
+    @Override
+    public void onDestroy() {
+        isServiceRunning = false;
+        try{
+            unregisterReceiver(estimator);
+        } catch (IllegalArgumentException e) {
+            logE(TAG, "Estimator receiver is not registered!");
+            e.printStackTrace();
+    }
+        estimator = null;
+    }
+
+}

--- a/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/BatteryService.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/BatteryService.java
@@ -55,12 +55,12 @@ public class BatteryService extends Service {
     @Override
     public void onDestroy() {
         isServiceRunning = false;
-        try{
+        try {
             unregisterReceiver(estimator);
         } catch (IllegalArgumentException e) {
             logE(TAG, "Estimator receiver is not registered!");
             e.printStackTrace();
-    }
+        }
         estimator = null;
     }
 

--- a/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/DataEstimator.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/DataEstimator.java
@@ -280,7 +280,7 @@ public class DataEstimator extends BroadcastReceiver {
 
             Intent service = new Intent(mContext, DataEstimatorService.class);
             service.putExtra("OriginalAction", mAction);
-            service.putExtra("jobID", ""+jobID);
+            service.putExtra("jobID", "" + jobID);
             service.fillIn(mIntent, 0);
 
             startService(service);

--- a/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/DataEstimator.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/DataEstimator.java
@@ -280,7 +280,6 @@ public class DataEstimator extends BroadcastReceiver {
 
             Intent service = new Intent(mContext, DataEstimatorService.class);
             service.putExtra("OriginalAction", mAction);
-            service.putExtra("jobID", "" + jobID);
             service.fillIn(mIntent, 0);
 
             startService(service);

--- a/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/DataEstimator.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/DataEstimator.java
@@ -17,7 +17,12 @@
 package com.hmatalonga.greenhub.managers.sampling;
 
 
+import android.app.job.JobInfo;
+import android.app.job.JobParameters;
+import android.app.job.JobScheduler;
+import android.app.job.JobService;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -26,7 +31,6 @@ import android.os.BatteryManager;
 
 import com.hmatalonga.greenhub.R;
 import com.hmatalonga.greenhub.events.BatteryLevelEvent;
-import com.hmatalonga.greenhub.util.LogUtils;
 import com.hmatalonga.greenhub.util.Notifier;
 import com.hmatalonga.greenhub.util.SettingsUtils;
 
@@ -47,8 +51,12 @@ public class DataEstimator extends BroadcastReceiver {
 
     private static final String TAG = makeLogTag(DataEstimator.class);
 
-    private long mLastNotify;
+    private static int mJobId = 0;
+    private static Context mContext;
+    private static Intent mIntent;
+    private static String mAction;
 
+    private long mLastNotify;
     private int mHealth;
     private int mLevel;
     private int mPlugged;
@@ -61,6 +69,7 @@ public class DataEstimator extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        mContext = context;
         //region null conditionals validations
         if (context == null) {
             logE(TAG, "Error, context is null");
@@ -72,17 +81,18 @@ public class DataEstimator extends BroadcastReceiver {
             return;
         }
 
-        String action = intent.getAction();
+        mIntent = intent;
+        mAction = intent.getAction();
 
-        if (action == null) {
+        if (mAction == null) {
             logE(TAG, "Intent has no action");
             return;
         }
         //endregion
 
-        logI(TAG, "ENTRY onReceive => " + action);
+        logI(TAG, "ENTRY onReceive => " + mAction);
 
-        if (!action.equals(Intent.ACTION_BATTERY_CHANGED)) return;
+        if (!mAction.equals(Intent.ACTION_BATTERY_CHANGED)) return;
 
         // Fetch Intent extras related to the battery state
         try {
@@ -150,14 +160,23 @@ public class DataEstimator extends BroadcastReceiver {
         if (mLevel > 0) {
             Inspector.setCurrentBatteryLevel(mLevel, mScale);
 
-            Intent service = new Intent(context, DataEstimatorService.class);
-            service.putExtra("OriginalAction", action);
-            service.fillIn(intent, 0);
-
             EventBus.getDefault().post(new BatteryLevelEvent(mLevel));
 
-            (context, service);
+            scheduleJob(context);
         }
+
+    }
+
+    private static void scheduleJob(Context context) {
+        ComponentName serviceComponent = new ComponentName(context, EstimatorJob.class);
+        JobInfo.Builder builder = new JobInfo.Builder(mJobId++, serviceComponent);
+        builder.setMinimumLatency(1); // wait at least
+        builder.setOverrideDeadline(10); // maximum delay
+        builder.setRequiresCharging(false);
+        builder.setRequiresDeviceIdle(false);
+
+        JobScheduler jobScheduler = context.getSystemService(JobScheduler.class);
+        jobScheduler.schedule(builder.build());
     }
 
     public static Intent getBatteryChangedIntent(final Context context) {
@@ -246,6 +265,34 @@ public class DataEstimator extends BroadcastReceiver {
         }
 
         return status;
+    }
+
+    public static class EstimatorJob extends JobService {
+        public static final String TAG = "EstimatorJob";
+
+        public EstimatorJob() {
+
+        }
+
+        @Override
+        public boolean onStartJob(JobParameters params) {
+            final int jobID = params.getJobId();
+
+            Intent service = new Intent(mContext, DataEstimatorService.class);
+            service.putExtra("OriginalAction", mAction);
+            service.putExtra("jobID", ""+jobID);
+            service.fillIn(mIntent, 0);
+
+            startService(service);
+            jobFinished(params, false);
+
+            return true;
+        }
+
+        @Override
+        public boolean onStopJob(JobParameters params) {
+            return false;
+        }
     }
 
     public long getmLastNotify() {

--- a/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/DataEstimatorService.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/DataEstimatorService.java
@@ -106,7 +106,6 @@ public class DataEstimatorService extends IntentService {
      */
     private void takeSampleIfBatteryLevelChanged(final Context context, Intent intent) {
         String action = intent.getAction();
-        String jobID = intent.getStringExtra("jobID");
         if (action == null) return;
 
         // Make sure our new sample doesn't have a zero value as its current battery level

--- a/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/DataEstimatorService.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/managers/sampling/DataEstimatorService.java
@@ -50,7 +50,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.BatteryManager;
 import android.os.Bundle;
-import android.os.PowerManager;
 
 import com.hmatalonga.greenhub.Config;
 import com.hmatalonga.greenhub.R;
@@ -85,36 +84,12 @@ public class DataEstimatorService extends IntentService {
 
     @Override
     protected void onHandleIntent(Intent intent) {
-        // At this point SimpleWakefulReceiver is still holding a wake lock
-        // for us. We can do whatever we need to here and then tell it that
-        // it can release the wakelock. This sample just does some slow work,
-        // but more complicated implementations could take their own wake
-        // lock here before releasing the receiver's.
-        //
-        // Note that when using this approach you should be aware that if your
-        // service gets killed and restarted while in the middle of such work
-        // (so the Intent gets re-delivered to perform the work again), it will
-        // at that point no longer be holding a wake lock since we are depending
-        // on SimpleWakefulReceiver to that for us. If this is a concern, you
-        // can
-        // acquire a separate wake lock here.
-        PowerManager powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
-        PowerManager.WakeLock wakeLock =
-                powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG);
-
-        wakeLock.acquire();
-
         Context context = getApplicationContext();
 
         if (intent != null) {
             takeSampleIfBatteryLevelChanged(context, intent);
         }
 
-        wakeLock.release();
-
-        if (intent != null) {
-            DataEstimator.(intent);
-        }
     }
 
     /**
@@ -131,6 +106,7 @@ public class DataEstimatorService extends IntentService {
      */
     private void takeSampleIfBatteryLevelChanged(final Context context, Intent intent) {
         String action = intent.getAction();
+        String jobID = intent.getStringExtra("jobID");
         if (action == null) return;
 
         // Make sure our new sample doesn't have a zero value as its current battery level

--- a/app/src/main/java/com/hmatalonga/greenhub/ui/MainActivity.java
+++ b/app/src/main/java/com/hmatalonga/greenhub/ui/MainActivity.java
@@ -179,7 +179,7 @@ public class MainActivity extends BaseActivity implements Toolbar.OnMenuItemClic
     }
 
     public DataEstimator getEstimator() {
-        return mApp.estimator;
+        return mApp.getEstimator();
     }
 
     private void loadComponents() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.jvmargs=-Xmx1536M
 compileSdkVersion = 27
 buildToolsVersion = 27.0.3
 
-minSdkVersion = 19
+minSdkVersion = 23
 targetSdkVersion = 27
 versionCode = 15
 versionName = v1.2.0


### PR DESCRIPTION
This PR fixes issues #79 and #82. 

The `DataEstimator` class changed from a deprecated `WakefulBroadcastReceiver` to a standard `BroadcastReceiver`, which is now controlled by an independet `Service`. Each time an event of the type `BATTERY_CHANGED` is detected, `DataEstimator` schedules a new job (of type `JobService`) to be executed immediately. The job will be responsible for starting the `DataEstimatorService`, which is responsible for taking the sample. 

The `DataEstimator` class could work in the same way without having a `JobScheduler` scheduling `JobServices`, and instead just starting the `DataEstimatorService` itself. I decided to maintain this scheduling approach because, as the [`JobScheduler` documentation](https://developer.android.com/reference/android/app/job/JobScheduler) states:

> While a job is running, the system holds a wakelock on behalf of your app. 

We are not sure if it is possible to have a scenario where a wakelock is necessary so the sampling process is not interrupted (and we don't have a proper way of testing it). Therefore, the explicit use of a `JobScheduler` is the safest approach.